### PR TITLE
修复StringType isOneOf方法bug

### DIFF
--- a/src/StringType.js
+++ b/src/StringType.js
@@ -38,7 +38,7 @@ class StringType extends Type {
   }
 
   isOneOf(strArr, errorMessage) {
-    super.pushRule(v => strArr.includes(v), errorMessage);
+    super.pushRule(v => !!~strArr.indexOf(v), errorMessage);
     return this;
   }
 

--- a/src/StringType.js
+++ b/src/StringType.js
@@ -38,7 +38,7 @@ class StringType extends Type {
   }
 
   isOneOf(strArr, errorMessage) {
-    super.pushRule(v => ~strArr.indexOf(v), errorMessage);
+    super.pushRule(v => strArr.includes(v), errorMessage);
     return this;
   }
 

--- a/test/StringTypeSpec.js
+++ b/test/StringTypeSpec.js
@@ -62,4 +62,13 @@ describe('#StringType', () => {
     schema.checkForField('str', 'abcde').hasError.should.equal(true);
     schema.checkForField('str', 'abcde').errorMessage.should.equal('error1');
   });
+
+  it('Should be one of value in array', () => {
+    const schema = SchemaModel({
+      str: StringType().isOneOf(['A', 'B', 'C'], 'error')
+    })
+    schema.checkForField('str', 'A').hasError.should.equal(false)
+    schema.checkForField('str', 'D').hasError.should.equal(true)
+    schema.checkForField('str', 'D').errorMessage.should.equal('error')
+  })
 });


### PR DESCRIPTION
实际使用中发现StringType的IsOneOf方法不生效， 改用 array.includes方法进行判断。 补充了单元测试。