### PR TITLE
Adding typescript declarations.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,4 @@
 src/
+types/*.json
+types/test.ts
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+- Adding the typescript types declaration in to package
+
 # 1.3.1
 
 - Fixed an issue where `isOneOf` was not valid in `StringType` (#18)

--- a/package.json
+++ b/package.json
@@ -4,14 +4,16 @@
   "description": "Schema for data modeling & validation",
   "main": "lib/index.js",
   "module": "es/index.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "lint": "eslint src  *.js",
     "build": "./node_modules/.bin/babel -d lib/ src/",
     "build-es": "NODE_ENV=esm ./node_modules/.bin/babel -d es/ src/",
-    "prepublish": "npm run test && npm run build && npm run build-es",
+    "prepublish": "npm run test && npm run test-types && npm run build && npm run build-es",
     "tdd": "mocha --watch --compilers js:@babel/register test/*Spec.js ",
     "test-once": "mocha --compilers js:@babel/register test/*Spec.js ",
-    "test": "npm run lint && npm run test-once"
+    "test": "npm run lint && npm run test-once",
+    "test-types": "dtslint --expectOnly --localTs node_modules/typescript/lib types"
   },
   "repository": {
     "type": "git",
@@ -31,7 +33,8 @@
   },
   "files": [
     "lib",
-    "es"
+    "es",
+    "types"
   ],
   "homepage": "https://github.com/rsuite/schema-typed#readme",
   "devDependencies": {
@@ -60,6 +63,7 @@
     "babel-eslint": "^9.0.0",
     "chai": "^3.5.0",
     "coveralls": "^2.13.1",
+    "dtslint": "^0.9.9",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^15.0.1",
     "eslint-plugin-babel": "^3.2.0",
@@ -70,6 +74,7 @@
     "eslint-plugin-react": "^7.3.0",
     "istanbul": "^0.4.5",
     "mocha": "^2.5.3",
-    "object-flaser": "^0.1.1"
+    "object-flaser": "^0.1.1",
+    "typescript": "^3.6.4"
   }
 }

--- a/types/ArrayType.d.ts
+++ b/types/ArrayType.d.ts
@@ -2,6 +2,7 @@ import { CheckType } from './SchemaDeclaration';
 import { Type } from './Type';
 
 export declare class ArrayType<ValueType = any, DataType = any, ErrorMsgType = string> extends Type<ValueType, DataType, ErrorMsgType> {
+    name: 'array';
     constructor(errorMessage?: ErrorMsgType);
     rangeLength: (minLength: number, maxLength: number, errorMessage?: ErrorMsgType) => this;
     minLength: (minLength: number, errorMessage?: ErrorMsgType) => this;

--- a/types/ArrayType.d.ts
+++ b/types/ArrayType.d.ts
@@ -1,0 +1,17 @@
+import { CheckType } from './SchemaDeclaration';
+import { Type } from './Type';
+
+export declare class ArrayType<ValueType = any, DataType = any, ErrorMsgType = string> extends Type<ValueType, DataType, ErrorMsgType> {
+    constructor(errorMessage?: ErrorMsgType);
+    rangeLength: (minLength: number, maxLength: number, errorMessage?: ErrorMsgType) => this;
+    minLength: (minLength: number, errorMessage?: ErrorMsgType) => this;
+    maxLength: (maxLength: number, errorMessage?: ErrorMsgType) => this;
+    unrepeatable: (errorMessage?: ErrorMsgType) => this;
+    of: (type: CheckType<ValueType, DataType, ErrorMsgType>, errorMessage?: ErrorMsgType) => this;
+}
+
+declare function getArrayType<ValueType = any, DataType = any, ErrorMsgType = string>(errorMessage?: ErrorMsgType): ArrayType<ValueType, DataType, ErrorMsgType>;
+
+type exportType = typeof getArrayType;
+
+export default exportType;

--- a/types/ArrayType.d.ts
+++ b/types/ArrayType.d.ts
@@ -2,7 +2,7 @@ import { CheckType } from './SchemaDeclaration';
 import { Type } from './Type';
 
 export declare class ArrayType<ValueType = any, DataType = any, ErrorMsgType = string> extends Type<ValueType, DataType, ErrorMsgType> {
-    name: 'array';
+    readonly name: 'array';
     constructor(errorMessage?: ErrorMsgType);
     rangeLength: (minLength: number, maxLength: number, errorMessage?: ErrorMsgType) => this;
     minLength: (minLength: number, errorMessage?: ErrorMsgType) => this;

--- a/types/BooleanType.d.ts
+++ b/types/BooleanType.d.ts
@@ -1,0 +1,11 @@
+import { Type } from './Type';
+
+export declare class BooleanType<DataType = any, ErrorMsgType = string> extends Type<boolean, DataType, ErrorMsgType> {
+    constructor(errorMessage?: ErrorMsgType);
+}
+
+declare function getBooleanType<DataType = any, ErrorMsgType = string>(errorMessage?: ErrorMsgType): BooleanType<DataType, ErrorMsgType>;
+
+type exportType = typeof getBooleanType;
+
+export default exportType;

--- a/types/BooleanType.d.ts
+++ b/types/BooleanType.d.ts
@@ -1,7 +1,7 @@
 import { Type } from './Type';
 
 export declare class BooleanType<DataType = any, ErrorMsgType = string> extends Type<boolean, DataType, ErrorMsgType> {
-    name: 'boolean';
+    readonly name: 'boolean';
     constructor(errorMessage?: ErrorMsgType);
 }
 

--- a/types/BooleanType.d.ts
+++ b/types/BooleanType.d.ts
@@ -1,6 +1,7 @@
 import { Type } from './Type';
 
 export declare class BooleanType<DataType = any, ErrorMsgType = string> extends Type<boolean, DataType, ErrorMsgType> {
+    name: 'boolean';
     constructor(errorMessage?: ErrorMsgType);
 }
 

--- a/types/DateType.d.ts
+++ b/types/DateType.d.ts
@@ -1,0 +1,14 @@
+import { Type } from './Type';
+
+export declare class DateType<DataType = any, ErrorMsgType = string> extends Type<string | Date, DataType, ErrorMsgType> {
+    constructor(errorMessage?: ErrorMsgType);
+    range: (min: string | Date, max: string | Date, errorMessage?: ErrorMsgType) => this;
+    min: (min: string | Date, errorMessage?: ErrorMsgType) => this;
+    max: (max: string | Date, errorMessage?: ErrorMsgType) => this;
+}
+
+declare function getDateType<DataType = any, ErrorMsgType = string>(errorMessage?: ErrorMsgType): DateType<DataType, ErrorMsgType>;
+
+type exportType = typeof getDateType;
+
+export default exportType;

--- a/types/DateType.d.ts
+++ b/types/DateType.d.ts
@@ -1,7 +1,7 @@
 import { Type } from './Type';
 
 export declare class DateType<DataType = any, ErrorMsgType = string> extends Type<string | Date, DataType, ErrorMsgType> {
-    name: 'date';
+    readonly name: 'date';
     constructor(errorMessage?: ErrorMsgType);
     range: (min: string | Date, max: string | Date, errorMessage?: ErrorMsgType) => this;
     min: (min: string | Date, errorMessage?: ErrorMsgType) => this;

--- a/types/DateType.d.ts
+++ b/types/DateType.d.ts
@@ -1,6 +1,7 @@
 import { Type } from './Type';
 
 export declare class DateType<DataType = any, ErrorMsgType = string> extends Type<string | Date, DataType, ErrorMsgType> {
+    name: 'date';
     constructor(errorMessage?: ErrorMsgType);
     range: (min: string | Date, max: string | Date, errorMessage?: ErrorMsgType) => this;
     min: (min: string | Date, errorMessage?: ErrorMsgType) => this;

--- a/types/NumberType.d.ts
+++ b/types/NumberType.d.ts
@@ -1,0 +1,17 @@
+import { Type } from './Type';
+
+export declare class NumberType<DataType = any, ErrorMsgType = string> extends Type<number, DataType, ErrorMsgType> {
+    constructor(errorMessage?: ErrorMsgType);
+    isInteger: (errorMessage?: ErrorMsgType) => this;
+    pattern: (regexp: RegExp, errorMessage?: ErrorMsgType) => this;
+    isOneOf: (numLst: number[], errorMessage?: ErrorMsgType) => this;
+    range: (min: number, max: number, errorMessage?: ErrorMsgType) => this;
+    min: (min: number, errorMessage?: ErrorMsgType) => this;
+    max: (max: number, errorMessage?: ErrorMsgType) => this;
+}
+
+declare function getNumberType<DataType = any, ErrorMsgType = string>(errorMessage?: ErrorMsgType): NumberType<DataType, ErrorMsgType>;
+
+type exportType = typeof getNumberType;
+
+export default exportType;

--- a/types/NumberType.d.ts
+++ b/types/NumberType.d.ts
@@ -1,7 +1,7 @@
 import { Type } from './Type';
 
 export declare class NumberType<DataType = any, ErrorMsgType = string> extends Type<number, DataType, ErrorMsgType> {
-    name: 'number';
+    readonly name: 'number';
     constructor(errorMessage?: ErrorMsgType);
     isInteger: (errorMessage?: ErrorMsgType) => this;
     pattern: (regexp: RegExp, errorMessage?: ErrorMsgType) => this;

--- a/types/NumberType.d.ts
+++ b/types/NumberType.d.ts
@@ -1,6 +1,7 @@
 import { Type } from './Type';
 
 export declare class NumberType<DataType = any, ErrorMsgType = string> extends Type<number, DataType, ErrorMsgType> {
+    name: 'number';
     constructor(errorMessage?: ErrorMsgType);
     isInteger: (errorMessage?: ErrorMsgType) => this;
     pattern: (regexp: RegExp, errorMessage?: ErrorMsgType) => this;

--- a/types/ObjectType.d.ts
+++ b/types/ObjectType.d.ts
@@ -2,6 +2,7 @@ import { SchemaDeclaration } from './SchemaDeclaration';
 import { Type } from './Type';
 
 export declare class ObjectType<ValueType = any, DataType = any, ErrorMsgType = string> extends Type<ValueType, DataType, ErrorMsgType> {
+    name: 'object';
     constructor(errorMessage?: ErrorMsgType);
     shape: (types: SchemaDeclaration<ValueType, ErrorMsgType>) => this;
 }

--- a/types/ObjectType.d.ts
+++ b/types/ObjectType.d.ts
@@ -2,7 +2,7 @@ import { SchemaDeclaration } from './SchemaDeclaration';
 import { Type } from './Type';
 
 export declare class ObjectType<ValueType = any, DataType = any, ErrorMsgType = string> extends Type<ValueType, DataType, ErrorMsgType> {
-    name: 'object';
+    readonly name: 'object';
     constructor(errorMessage?: ErrorMsgType);
     shape: (types: SchemaDeclaration<ValueType, ErrorMsgType>) => this;
 }

--- a/types/ObjectType.d.ts
+++ b/types/ObjectType.d.ts
@@ -1,0 +1,13 @@
+import { SchemaDeclaration } from './SchemaDeclaration';
+import { Type } from './Type';
+
+export declare class ObjectType<ValueType = any, DataType = any, ErrorMsgType = string> extends Type<ValueType, DataType, ErrorMsgType> {
+    constructor(errorMessage?: ErrorMsgType);
+    shape: (types: SchemaDeclaration<ValueType, ErrorMsgType>) => this;
+}
+
+declare function getObjectType<ValueType = any, DataType = any, ErrorMsgType = string>(errorMessage?: ErrorMsgType): ObjectType<ValueType, DataType, ErrorMsgType>;
+
+type exportType = typeof getObjectType;
+
+export default exportType;

--- a/types/Schema.d.ts
+++ b/types/Schema.d.ts
@@ -1,0 +1,26 @@
+import { CheckType, SchemaDeclaration } from './SchemaDeclaration';
+import { CheckResult } from './Type';
+
+type SchemaCheckResult<T, ErrorMsgType> = {
+    [P in keyof T]: CheckResult<ErrorMsgType>
+};
+
+export declare class Schema<DataType = any, ErrorMsgType = string> {
+    constructor(schema: SchemaDeclaration<DataType, ErrorMsgType>);
+    schema: SchemaDeclaration<DataType, ErrorMsgType>;
+    getFieldType: <K extends keyof DataType>(fieldName: K) => CheckType<DataType[K], DataType, ErrorMsgType>;
+    getKeys: () => string[];
+    checkForField: <K extends keyof DataType>(fieldName: K, fieldValue: DataType[K], data?: DataType) => CheckResult<ErrorMsgType>;
+    checkForFieldAsync: <K extends keyof DataType>(fieldName: K, fieldValue: DataType[K], data?: DataType) => Promise<CheckResult<ErrorMsgType>>;
+    check: (data: DataType) => SchemaCheckResult<DataType, ErrorMsgType>;
+    checkAsync: (data: DataType) => Promise<SchemaCheckResult<DataType, ErrorMsgType>>;
+}
+
+declare function SchemaModel<DataType = any, ErrorMsgType = string>(schema: SchemaDeclaration<DataType, ErrorMsgType>): Schema<DataType>;
+
+declare namespace SchemaModel {
+    const combine: <DataType = any, ErrorMsgType = string>(...models: Array<Schema<any, ErrorMsgType>>) =>
+        Schema<DataType, ErrorMsgType>;
+}
+
+export default SchemaModel;

--- a/types/SchemaDeclaration.d.ts
+++ b/types/SchemaDeclaration.d.ts
@@ -5,7 +5,7 @@ import { NumberType } from './NumberType';
 import { StringType } from './StringType';
 import { ObjectType } from './ObjectType';
 
-export type CheckType<X, T, ErrorMsgType> =
+export type CheckType<X, T, ErrorMsgType = string> =
     X extends string ? StringType<T, ErrorMsgType> | DateType<T, ErrorMsgType> | NumberType<T, ErrorMsgType>:
         X extends number ? NumberType<T, ErrorMsgType>:
             X extends boolean ? BooleanType<T, ErrorMsgType>:
@@ -19,6 +19,6 @@ export type CheckType<X, T, ErrorMsgType> =
                             DateType<T, ErrorMsgType> |
                             ObjectType<X, T, ErrorMsgType>;
 
-export type SchemaDeclaration<T, ErrorMsgType> = {
+export type SchemaDeclaration<T, ErrorMsgType = string> = {
     [P in keyof T]: CheckType<T[P], T, ErrorMsgType>;
 }

--- a/types/SchemaDeclaration.d.ts
+++ b/types/SchemaDeclaration.d.ts
@@ -1,0 +1,24 @@
+import { ArrayType } from './ArrayType';
+import { BooleanType } from './BooleanType';
+import { DateType } from './DateType';
+import { NumberType } from './NumberType';
+import { StringType } from './StringType';
+import { ObjectType } from './ObjectType';
+
+export type CheckType<X, T, ErrorMsgType> =
+    X extends string ? StringType<T, ErrorMsgType> | DateType<T, ErrorMsgType> :
+        X extends number ? NumberType<T, ErrorMsgType>:
+            X extends boolean ? BooleanType<T, ErrorMsgType>:
+                X extends Date ? DateType<T, ErrorMsgType>:
+                    X extends Array<infer I> ? ArrayType<I, T, ErrorMsgType>:
+                        X extends object ? ObjectType<X, T, ErrorMsgType> :
+                            StringType<T, ErrorMsgType> |
+                            NumberType<T, ErrorMsgType> |
+                            BooleanType<T, ErrorMsgType> |
+                            ArrayType<any, T, ErrorMsgType> |
+                            DateType<T, ErrorMsgType> |
+                            ObjectType<X, T, ErrorMsgType>;
+
+export type SchemaDeclaration<T, ErrorMsgType> = {
+    [P in keyof T]: CheckType<T[P], T, ErrorMsgType>;
+}

--- a/types/SchemaDeclaration.d.ts
+++ b/types/SchemaDeclaration.d.ts
@@ -6,7 +6,7 @@ import { StringType } from './StringType';
 import { ObjectType } from './ObjectType';
 
 export type CheckType<X, T, ErrorMsgType> =
-    X extends string ? StringType<T, ErrorMsgType> | DateType<T, ErrorMsgType> :
+    X extends string ? StringType<T, ErrorMsgType> | DateType<T, ErrorMsgType> | NumberType<T, ErrorMsgType>:
         X extends number ? NumberType<T, ErrorMsgType>:
             X extends boolean ? BooleanType<T, ErrorMsgType>:
                 X extends Date ? DateType<T, ErrorMsgType>:

--- a/types/StringType.d.ts
+++ b/types/StringType.d.ts
@@ -1,7 +1,7 @@
 import { Type } from './Type';
 
 export declare class StringType<DataType = any, ErrorMsgType = string> extends Type<string, DataType, ErrorMsgType> {
-    name: 'string';
+    readonly name: 'string';
     constructor(errorMessage?: ErrorMsgType);
     containsLetter: (errorMessage?: ErrorMsgType) => this;
     containsUppercaseLetter: (errorMessage?: ErrorMsgType) => this;

--- a/types/StringType.d.ts
+++ b/types/StringType.d.ts
@@ -1,6 +1,7 @@
 import { Type } from './Type';
 
 export declare class StringType<DataType = any, ErrorMsgType = string> extends Type<string, DataType, ErrorMsgType> {
+    name: 'string';
     constructor(errorMessage?: ErrorMsgType);
     containsLetter: (errorMessage?: ErrorMsgType) => this;
     containsUppercaseLetter: (errorMessage?: ErrorMsgType) => this;

--- a/types/StringType.d.ts
+++ b/types/StringType.d.ts
@@ -1,0 +1,24 @@
+import { Type } from './Type';
+
+export declare class StringType<DataType = any, ErrorMsgType = string> extends Type<string, DataType, ErrorMsgType> {
+    constructor(errorMessage?: ErrorMsgType);
+    containsLetter: (errorMessage?: ErrorMsgType) => this;
+    containsUppercaseLetter: (errorMessage?: ErrorMsgType) => this;
+    containsLowercaseLetter: (errorMessage?: ErrorMsgType) => this;
+    containsLetterOnly: (errorMessage?: ErrorMsgType) => this;
+    containsNumber: (errorMessage?: ErrorMsgType) => this;
+    isOneOf: (strArr: string[], errorMessage?: ErrorMsgType) => this;
+    isEmail: (errorMessage?: ErrorMsgType) => this;
+    isURL: (errorMessage?: ErrorMsgType) => this;
+    isHex: (errorMessage?: ErrorMsgType) => this;
+    pattern: (regexp: RegExp, errorMessage?: ErrorMsgType) => this;
+    rangeLength: (minLength: number, maxLength: number, errorMessage?: ErrorMsgType) => this;
+    minLength: (minLength: number, errorMessage?: ErrorMsgType) => this;
+    maxLength: (maxLength: number, errorMessage?: ErrorMsgType) => this;
+}
+
+declare function getStringType<DataType = any, ErrorMsgType = string>(errorMessage?: ErrorMsgType): StringType<DataType, ErrorMsgType>;
+
+type exportType = typeof getStringType;
+
+export default exportType;

--- a/types/Type.d.ts
+++ b/types/Type.d.ts
@@ -1,0 +1,17 @@
+interface CheckResult<ErrorMsgType = string> {
+    hasError: boolean;
+    errorMessage: ErrorMsgType;
+}
+
+declare class Type<ValueType = any, DataType = any, ErrorMsgType = string> {
+    constructor(name: PropertyKey);
+    check: (value: ValueType, data: any) => CheckResult<ErrorMsgType>;
+    addRule: (
+        onValid: (value: ValueType, data: DataType) =>
+            CheckResult<ErrorMsgType> | boolean  | void | undefined | Promise<boolean> | Promise<CheckResult<ErrorMsgType>> | Promise<void>,
+        errorMessage?: ErrorMsgType
+    ) => this;
+    isRequired: (errorMessage?: ErrorMsgType) => this;
+}
+
+export { CheckResult, Type };

--- a/types/Type.d.ts
+++ b/types/Type.d.ts
@@ -4,7 +4,8 @@ interface CheckResult<ErrorMsgType = string> {
 }
 
 declare class Type<ValueType = any, DataType = any, ErrorMsgType = string> {
-    constructor(name: PropertyKey);
+    name: string;
+    constructor(name: string);
     check: (value: ValueType, data: any) => CheckResult<ErrorMsgType>;
     addRule: (
         onValid: (value: ValueType, data: DataType) =>

--- a/types/Type.d.ts
+++ b/types/Type.d.ts
@@ -4,7 +4,7 @@ interface CheckResult<ErrorMsgType = string> {
 }
 
 declare class Type<ValueType = any, DataType = any, ErrorMsgType = string> {
-    name: string;
+    readonly name: string;
     constructor(name: string);
     check: (value: ValueType, data: any) => CheckResult<ErrorMsgType>;
     addRule: (

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,49 @@
+import ArrayType, { ArrayType as ArrayCheckType } from './ArrayType';
+import BooleanType, { BooleanType as BooleanCheckType } from './BooleanType';
+import DateType, { DateType as DateCheckType } from './DateType';
+import NumberType, { NumberType as NumberCheckType } from './NumberType';
+import StringType, { StringType as StringCheckType } from './StringType';
+import ObjectType, { ObjectType as ObjectCheckType } from './ObjectType';
+import SchemaModel, { Schema } from './Schema';
+import { SchemaDeclaration } from './SchemaDeclaration';
+
+export type CheckType<DataType = any> =
+    ArrayCheckType<any, DataType>
+    | BooleanCheckType<DataType>
+    | DateCheckType<DataType>
+    | NumberCheckType<DataType>
+    | StringCheckType<DataType>
+    | ObjectCheckType<any, DataType>;
+
+declare const ArrayType: ArrayType;
+declare const BooleanType: BooleanType;
+declare const DateType: DateType;
+declare const StringType: StringType;
+declare const ObjectType: ObjectType;
+declare const NumberType: NumberType;
+
+export {
+    ArrayType,
+    BooleanType,
+    DateType,
+    StringType,
+    ObjectType,
+    NumberType,
+    SchemaModel,
+    SchemaDeclaration,
+    Schema
+}
+
+declare namespace SchemaNs {
+    const Model: typeof SchemaModel;
+    const Types: {
+        StringType: StringType;
+        NumberType: NumberType;
+        ArrayType: ArrayType;
+        DateType: DateType;
+        ObjectType: ObjectType;
+        BooleanType: BooleanType;
+    };
+}
+
+export default SchemaNs;

--- a/types/test.ts
+++ b/types/test.ts
@@ -77,14 +77,9 @@ SchemaModel<{a: string}>({
 interface F1 {a: string}
 new Schema<F1>({
     // $ExpectError
-    a: NumberType()
-    // TS2322: Type 'NumberType<F1>' is not assignable to type 'StringType<F1> | DateType<F1>'.
-    //   Type 'NumberType<F1>' is not assignable to type 'DateType<F1>'.
-    //     Types of property 'range' are incompatible.
-    //       Type '(min: number, max: number, errorMessage: string) => NumberType<F1>' is not assignable to type '(min: string | Date, max: string | Date, errorMessage: string) => DateType<F1>'.
-    //         Types of parameters 'min' and 'min' are incompatible.
-    //           Type 'string | Date' is not assignable to type 'number'.
-    //             Type 'string' is not assignable to type 'number'.
+    a: BooleanType()
+    // TS2322: Type 'BooleanType<F1, string>' is not assignable to type 'StringType<F1, string> | DateType<F1, string> | NumberType<F1, string>'.
+    //   Type 'BooleanType<F1, string>' is missing the following properties from type 'NumberType<F1, string>': isInteger, pattern, isOneOf, range, and 2 more.
 });
 
 
@@ -201,14 +196,9 @@ schemaF8.checkForFieldAsync('c', 'a');
 interface F9 {a: string}
 ObjectType<F9>().shape({
     // $ExpectError
-    a: NumberType()
-    // TS2322: Type 'NumberType<F9>' is not assignable to type 'StringType<F9> | DateType<F9>'.
-    //   Type 'NumberType<F9>' is not assignable to type 'DateType<F9>'.
-    //     Types of property 'range' are incompatible.
-    //       Type '(min: number, max: number, errorMessage: string) => NumberType<F9>' is not assignable to type '(min: string | Date, max: string | Date, errorMessage: string) => DateType<F9>'.
-    //         Types of parameters 'min' and 'min' are incompatible.
-    //           Type 'string | Date' is not assignable to type 'number'.
-    //             Type 'string' is not assignable to type 'number'.
+    a: BooleanType()
+    // TS2322: Type 'BooleanType<F9, string>' is not assignable to type 'StringType<F9, string> | DateType<F9, string> | NumberType<F9, string>'.
+    //   Type 'BooleanType<F9, string>' is missing the following properties from type 'NumberType<F9, string>': isInteger, pattern, isOneOf, range, and 2 more.
 });
 ObjectType<F9>().shape({
     // $ExpectError

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,0 +1,197 @@
+import {
+    BooleanType,
+    NumberType,
+    StringType,
+    DateType,
+    ArrayType,
+    ObjectType,
+    Schema,
+    SchemaModel
+} from './index';
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// PASSING SCENARIO 1: Should not fail if proper check types are used
+
+interface PassObj {s: string}
+interface Pass {n: number, b: boolean, s: string, d: Date, a: Array<string>, o: PassObj }
+
+const passSchema = new Schema<Pass>({
+    n: NumberType<Pass>(),
+    b: BooleanType<Pass>(),
+    s: StringType<Pass>(),
+    d: DateType<Pass>(),
+    a: ArrayType<string, Pass>(),
+    o: ObjectType<PassObj, Pass>(),
+});
+
+passSchema.check({a: ['a'], b: false, d: new Date(), n: 0, o: {s: ""}, s: ""});
+passSchema.checkAsync({a: ['a'], b: false, d: new Date(), n: 0, o: {s: ""}, s: ""});
+passSchema.checkForField("o", {s : "1"});
+passSchema.checkForFieldAsync("o", {s : "1"});
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// PASSING SCENARIO 2: Should allows combine proper schemas
+
+SchemaModel.combine<{x: string, y: string}>(
+    new Schema<{x: string}>({x: StringType()}),
+    new Schema<{y: string}>({y: StringType()}));
+
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// FAIL SCENARIO 1: Should fail if type check is not matching declared type
+
+interface F1 {a: string}
+new Schema<F1>({
+    // $ExpectError
+    a: NumberType()
+    // TS2322: Type 'NumberType<F1>' is not assignable to type 'StringType<F1> | DateType<F1>'.
+    //   Type 'NumberType<F1>' is not assignable to type 'DateType<F1>'.
+    //     Types of property 'range' are incompatible.
+    //       Type '(min: number, max: number, errorMessage: string) => NumberType<F1>' is not assignable to type '(min: string | Date, max: string | Date, errorMessage: string) => DateType<F1>'.
+    //         Types of parameters 'min' and 'min' are incompatible.
+    //           Type 'string | Date' is not assignable to type 'number'.
+    //             Type 'string' is not assignable to type 'number'.
+});
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// FAIL SCENARIO 2: Should fail if checks declaration provides check for undeclared property
+
+interface F2 {a: string}
+new Schema<F2>({
+    // $ExpectError
+    b: NumberType()
+    // TS2345: Argument of type '{ b: NumberType<any>; }' is not assignable to parameter of type 'SchemaDeclaration<F2>'.
+    //   Object literal may only specify known properties, and 'b' does not exist in type 'SchemaDeclaration<F2>'.
+});
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// FAIL SCENARIO 3: Should fail if custom rule check will not fallow proper type for value
+
+interface F3 {a: string}
+new Schema<F3>({
+    // $ExpectError
+    a: StringType().addRule((v: number) => true)
+    // TS2345: Argument of type '(v: number) => true' is not assignable to parameter of type '(value: string, data: any) => boolean | void | CheckResult<string> | Promise<boolean> | Promise<void> | Promise<CheckResult<string>>'.
+    //   Types of parameters 'v' and 'value' are incompatible.
+    //     Type 'string' is not assignable to type 'number'.
+});
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// FAIL SCENARIO 4: Should fail if custom rule check will not fallow proper type for data
+
+interface F4 {a: string}
+new Schema<F4>({
+    // $ExpectError
+    a: StringType<F4>().addRule((v: string, d: number) => true)
+    // TS2345: Argument of type '(v: string, d: number) => true' is not assignable to parameter of type '(value: string, data: F4) => boolean | void | CheckResult<string> | Promise<boolean> | Promise<void> | Promise<CheckResult<string>>'.
+    //   Types of parameters 'd' and 'data' are incompatible.
+    //     Type 'F4' is not assignable to type 'number'.
+});
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// FAIL SCENARIO 5: Should fail if check and checkAsync function is called with not matching type
+
+interface F5 {a: string}
+const schemaF5 = new Schema<F5>({
+    a: StringType()
+});
+
+// $ExpectError
+schemaF5.check({ c: 12});
+// TS2345: Argument of type '{ c: number; }' is not assignable to parameter of type 'F5'.
+//   Object literal may only specify known properties, and 'c' does not exist in type 'F5'.
+
+// $ExpectError
+schemaF5.checkAsync({ c: 12});
+// TS2345: Argument of type '{ c: number; }' is not assignable to parameter of type 'F5'.
+//   Object literal may only specify known properties, and 'c' does not exist in type 'F5'.
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// FAIL SCENARIO 6: Should fail if checkForField function is called with non existing property name
+
+interface F6 {a: string}
+const schemaF6 = new Schema<F6>({
+    a: StringType()
+});
+
+// $ExpectError
+schemaF6.checkForField('c', 'a');
+// TS2345: Argument of type '"c"' is not assignable to parameter of type '"a"'.
+
+// $ExpectError
+schemaF6.checkForFieldAsync('c', 'a');
+// TS2345: Argument of type '"c"' is not assignable to parameter of type '"a"'.
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// FAIL SCENARIO 7: Should fail if check and checkAsync function is called with not matching type, when type is inferred
+
+const schemaF7 = new Schema({
+    a: StringType()
+});
+
+// $ExpectError
+schemaF7.check({ c: 12});
+// TS2345: Argument of type '{ c: number; }' is not assignable to parameter of type '{ a: unknown; }'.
+//   Object literal may only specify known properties, and 'c' does not exist in type '{ a: unknown; }'.
+
+// $ExpectError
+schemaF7.checkAsync({ c: 12});
+// TS2345: Argument of type '{ c: number; }' is not assignable to parameter of type '{ a: unknown; }'.
+//   Object literal may only specify known properties, and 'c' does not exist in type '{ a: unknown; }'.
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// FAIL SCENARIO 8: Should fail if checkForField function is called with non existing property name, when type is inferred
+
+const schemaF8 = new Schema({
+    a: StringType()
+});
+
+// $ExpectError
+schemaF8.checkForField('c', 'a');
+// TS2345: Argument of type '"c"' is not assignable to parameter of type '"a"'.
+
+// $ExpectError
+schemaF8.checkForFieldAsync('c', 'a');
+// TS2345: Argument of type '"c"' is not assignable to parameter of type '"a"'.
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// FAIL SCENARIO 9: Should fail if ObjectType will get not matched shape
+
+interface F9 {a: string}
+ObjectType<F9>().shape({
+    // $ExpectError
+    a: NumberType()
+    // TS2322: Type 'NumberType<F9>' is not assignable to type 'StringType<F9> | DateType<F9>'.
+    //   Type 'NumberType<F9>' is not assignable to type 'DateType<F9>'.
+    //     Types of property 'range' are incompatible.
+    //       Type '(min: number, max: number, errorMessage: string) => NumberType<F9>' is not assignable to type '(min: string | Date, max: string | Date, errorMessage: string) => DateType<F9>'.
+    //         Types of parameters 'min' and 'min' are incompatible.
+    //           Type 'string | Date' is not assignable to type 'number'.
+    //             Type 'string' is not assignable to type 'number'.
+});
+ObjectType<F9>().shape({
+    // $ExpectError
+    b: NumberType()
+    // TS2345: Argument of type '{ b: NumberType<any>; }' is not assignable to parameter of type 'SchemaDeclaration<F9>'.
+    //   Object literal may only specify known properties, and 'b' does not exist in type 'SchemaDeclaration<F9>'.
+});
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// FAIL SCENARIO 10: Should fail if ArrayType will get not matched shape
+
+interface F10 {a: string}
+// $ExpectError
+ArrayType<F10>().of(StringType());
+// TS2345: Argument of type 'StringType<any>' is not assignable to parameter of type 'ObjectType<F10, any>'.
+//   Property 'shape' is missing in type 'StringType<any>' but required in type 'ObjectType<F10, any>'.
+

--- a/types/test.ts
+++ b/types/test.ts
@@ -16,12 +16,12 @@ interface PassObj {s: string}
 interface Pass {n: number, b: boolean, s: string, d: Date, a: Array<string>, o: PassObj }
 
 const passSchema = new Schema<Pass>({
-    n: NumberType<Pass>(),
-    b: BooleanType<Pass>(),
-    s: StringType<Pass>(),
-    d: DateType<Pass>(),
-    a: ArrayType<string, Pass>(),
-    o: ObjectType<PassObj, Pass>(),
+    n: NumberType(),
+    b: BooleanType(),
+    s: StringType(),
+    d: DateType(),
+    a: ArrayType<string>(),
+    o: ObjectType<PassObj>(),
 });
 
 passSchema.check({a: ['a'], b: false, d: new Date(), n: 0, o: {s: ""}, s: ""});
@@ -37,6 +37,38 @@ SchemaModel.combine<{x: string, y: string}>(
     new Schema<{x: string}>({x: StringType()}),
     new Schema<{y: string}>({y: StringType()}));
 
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// PASSING SCENARIO 3: Should allows adding custom rules which have proper types on callback
+
+SchemaModel<{password1: string, password2: string}>({
+    password1: StringType(),
+    password2: StringType().addRule((value, data) => value.toLowerCase() === data.password1.toLowerCase())
+});
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// PASSING SCENARIO 4: Should allows to use custom error message type
+SchemaModel<{a: string}, number>({
+    a: StringType<{a: string}, number>().addRule(() => ({
+        hasError: true,
+        errorMessage: 500,
+    }))
+});
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// PASSING SCENARIO 5: Should allows to use NumberType on string field
+SchemaModel<{a: string}>({
+    a: NumberType<{a: string}>()
+});
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// PASSING SCENARIO 6: Should allows to use DataType on string field
+SchemaModel<{a: string}>({
+    a: DateType<{a: string}>()
+});
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["es6"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": { "schema-typed": ["."] }
+  }
+}

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "dtslint/dtslint.json", // Or "dtslint/dt.json" if on DefinitelyTyped
+  "rules": {
+    "semicolon": false,
+    "indent": [true, "tabs"]
+  }
+}


### PR DESCRIPTION
Fixing #19

This PR have a 2 goals:

1. Move types declarations directly to library 
2. Create very strict types declarations which will plays well together typescript static types (eg. `StringType` can be used only to validate properties which are marked as `string`) 