### PR TITLE
fix(addRule): allow add return undefined

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export type ValidCallbackType<V, D, E> = (
   value: V,
   data?: D,
   filedName?: string | string[]
-) => CheckResult<E> | boolean;
+) => CheckResult<E> | boolean | undefined;
 export type PlainObject<T extends Record<string, unknown> = any> = {
   [P in keyof T]: T;
 };


### PR DESCRIPTION
当前addRule要求返回boolean 或 ErrorMessage
```ts
Schema.Types.StringType().addRule(value => {
  // empty
});
```
而代码中的逻辑是 返回 false 或 ErrorMessage 进行处理，没有返回值会被认为是通过的
所以对应的类型声明应允许返回空 