### PR TITLE
ci: remove nodejs 10 from testing matrix

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 15.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Node.js 10 is long out-of-maintenance, and it [blocks the upgrade of Mocha](https://github.com/rsuite/schema-typed/pull/55#issuecomment-1407621073).