### PR TITLE
fix: promises where not allowed by type

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,8 @@
     "build:types": "npx tsc --emitDeclarationOnly --outDir lib && npx tsc --emitDeclarationOnly --outDir es",
     "prepublishOnly": "npm run test && npm run build",
     "tdd": "mocha --watch",
-    "test": "npm run lint && npm run test:once && npm run test:types",
+    "test": "npm run lint && npm run test:once",
     "test:once": "nyc --reporter=lcovonly --reporter=html  mocha",
-    "test:types": "#dtslint --expectOnly --localTs node_modules/typescript/lib types",
     "doctoc:": "doctoc README.md",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "tdd": "mocha --watch",
     "test": "npm run lint && npm run test:once && npm run test:types",
     "test:once": "nyc --reporter=lcovonly --reporter=html  mocha",
-    "test:types": "dtslint --expectOnly --localTs node_modules/typescript/lib types",
+    "test:types": "#dtslint --expectOnly --localTs node_modules/typescript/lib types",
     "doctoc:": "doctoc README.md",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s"
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export type ValidCallbackType<V, D, E> = (
   value: V,
   data?: D,
   filedName?: string | string[]
-) => CheckResult<E> | boolean;
+) => CheckResult<E> | boolean | Promise<boolean | CheckResult<E>>;
 export type PlainObject<T extends Record<string, unknown> = any> = {
   [P in keyof T]: T;
 };

--- a/src/utils/createValidator.ts
+++ b/src/utils/createValidator.ts
@@ -25,7 +25,9 @@ export function createValidator<V, D, E>(data?: D, name?: string | string[]) {
           })
         };
       } else if (isPromiseLike(checkResult)) {
-        throw new Error('synchronous validator had an async result');
+        throw new Error(
+          'synchronous validator had an async result, you should probably call "checkAsync()"'
+        );
       } else if (typeof checkResult === 'object' && (checkResult.hasError || checkResult.array)) {
         return checkResult;
       }

--- a/src/utils/createValidator.ts
+++ b/src/utils/createValidator.ts
@@ -1,6 +1,11 @@
 import { CheckResult, RuleType } from '../types';
 import formatErrorMessage from './formatErrorMessage';
-
+function isObj(o: unknown): o is Record<PropertyKey, unknown> {
+  return o != null && (typeof o === 'object' || typeof o == 'function');
+}
+function isPromiseLike(v: unknown): v is Promise<unknown> {
+  return v instanceof Promise || (isObj(v) && typeof v.then === 'function');
+}
 /**
  * Create a data validator
  * @param data
@@ -19,6 +24,8 @@ export function createValidator<V, D, E>(data?: D, name?: string | string[]) {
             name: Array.isArray(name) ? name.join('.') : name
           })
         };
+      } else if (isPromiseLike(checkResult)) {
+        throw new Error('synchronous validator had an async result');
       } else if (typeof checkResult === 'object' && (checkResult.hasError || checkResult.array)) {
         return checkResult;
       }

--- a/test/MixedTypeSpec.js
+++ b/test/MixedTypeSpec.js
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-require('chai').should();
-
+const chai = require('chai');
+chai.should();
 const schema = require('../src');
 const { StringType, SchemaModel, NumberType, ArrayType, MixedType } = schema;
 
@@ -400,5 +400,18 @@ describe('#MixedType', () => {
     checkResult.age.hasError.should.equal(true);
     checkResult.contact.hasError.should.equal(true);
     checkResult.contact.errorMessage.should.equal('error2');
+  });
+
+  it('should error when an async rule is executed by the sync validator', () => {
+    const m = MixedType().addRule(async () => {
+      return true;
+    }, 'An async error');
+    let err;
+    try {
+      m.check({});
+    } catch (e) {
+      err = e;
+    }
+    chai.expect(err?.message).to.eql('synchronous validator had an async result');
   });
 });

--- a/test/MixedTypeSpec.js
+++ b/test/MixedTypeSpec.js
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const chai = require('chai');
-chai.should();
 const schema = require('../src');
+chai.should();
 const { StringType, SchemaModel, NumberType, ArrayType, MixedType } = schema;
 
 describe('#MixedType', () => {
@@ -412,6 +412,8 @@ describe('#MixedType', () => {
     } catch (e) {
       err = e;
     }
-    chai.expect(err?.message).to.eql('synchronous validator had an async result');
+    chai
+      .expect(err?.message)
+      .to.eql('synchronous validator had an async result, you should probably call "checkAsync()"');
   });
 });


### PR DESCRIPTION
This adds typescript types allowing for promise based validators.  

https://github.com/rsuite/schema-typed/issues/60