### PR TITLE
feat: addAsyncRule to allow sync and async rules to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ function asyncCheckEmail(email) {
 const model = SchemaModel({
   email: StringType()
     .isEmail('Please input the correct email address')
-    .addRule((value, data) => {
+    .addAsyncRule((value, data) => {
       return asyncCheckEmail(value);
     }, 'Email address already exists')
     .isRequired('This field cannot be empty')
@@ -391,7 +391,7 @@ Asynchronously check whether a field in the data conforms to the model shape def
 const model = SchemaModel({
   username: StringType()
     .isRequired('This field required')
-    .addRule(value => {
+    .addAsyncRule(value => {
       return new Promise(resolve => {
         // Asynchronous processing logic
       });

--- a/src/MixedType.ts
+++ b/src/MixedType.ts
@@ -2,6 +2,7 @@ import {
   SchemaDeclaration,
   CheckResult,
   ValidCallbackType,
+  AsyncValidCallbackType,
   RuleType,
   ErrorMessageType,
   TypeName
@@ -101,6 +102,7 @@ export class MixedType<ValueType = any, DataType = any, E = ErrorMessageType, L 
     const nextRule = {
       onValid,
       params,
+      isAsync: rule.isAsync,
       errorMessage: errorMessage || this.rules?.[0]?.errorMessage
     };
 
@@ -118,7 +120,14 @@ export class MixedType<ValueType = any, DataType = any, E = ErrorMessageType, L 
     this.pushRule({ onValid, errorMessage, priority });
     return this;
   }
-
+  addAsyncRule(
+    onValid: AsyncValidCallbackType<ValueType, DataType, E | string>,
+    errorMessage?: E | string,
+    priority?: boolean
+  ) {
+    this.pushRule({ onValid, isAsync: true, errorMessage, priority });
+    return this;
+  }
   isRequired(errorMessage: E | string = this.locale.isRequired, trim = true) {
     this.required = true;
     this.trim = trim;

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,14 @@ export type ValidCallbackType<V, D, E> = (
   value: V,
   data?: D,
   filedName?: string | string[]
+) => CheckResult<E> | boolean;
+
+export type AsyncValidCallbackType<V, D, E> = (
+  value: V,
+  data?: D,
+  filedName?: string | string[]
 ) => CheckResult<E> | boolean | Promise<boolean | CheckResult<E>>;
+
 export type PlainObject<T extends Record<string, unknown> = any> = {
   [P in keyof T]: T;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,10 +33,11 @@ export type PlainObject<T extends Record<string, unknown> = any> = {
 };
 
 export interface RuleType<V, D, E> {
-  onValid: ValidCallbackType<V, D, E>;
+  onValid: AsyncValidCallbackType<V, D, E>;
   errorMessage?: E;
   priority?: boolean;
   params?: any;
+  isAsync?: boolean;
 }
 
 export type CheckType<X, T, E = ErrorMessageType> = X extends string

--- a/src/utils/createValidator.ts
+++ b/src/utils/createValidator.ts
@@ -13,7 +13,8 @@ function isPromiseLike(v: unknown): v is Promise<unknown> {
 export function createValidator<V, D, E>(data?: D, name?: string | string[]) {
   return (value: V, rules: RuleType<V, D, E>[]): CheckResult<E> | null => {
     for (let i = 0; i < rules.length; i += 1) {
-      const { onValid, errorMessage, params } = rules[i];
+      const { onValid, errorMessage, params, isAsync } = rules[i];
+      if (isAsync) continue;
       const checkResult = onValid(value, data, name);
 
       if (checkResult === false) {

--- a/test/MixedTypeSpec.js
+++ b/test/MixedTypeSpec.js
@@ -449,11 +449,15 @@ describe('#MixedType', () => {
       }, 'error1')
       .isRequired('error2');
     setTimeout(() => {
-      chai.expect(called).to.eq(false);
-      chai.expect(type.check('').hasError).to.eq(true);
-      chai.expect(type.check('1').hasError).to.eq(true);
-      chai.expect(type.check(1).hasError).to.eq(false);
-      done();
+      try {
+        chai.expect(called).to.eq(false);
+        chai.expect(type.check('').hasError).to.eq(true);
+        chai.expect(type.check('1').hasError).to.eq(true);
+        chai.expect(type.check(1).hasError).to.eq(false);
+        done();
+      } catch (e) {
+        done(e);
+      }
     }, 100);
   });
 });

--- a/test/MixedTypeSpec.js
+++ b/test/MixedTypeSpec.js
@@ -437,7 +437,7 @@ describe('#MixedType', () => {
       }
     });
   });
-  it('Should be able to check by `check` with `addAsyncRule` and skip the async ', (done) => {
+  it('Should be able to check by `check` with `addAsyncRule` and skip the async ', done => {
     let called = false;
     const type = MixedType()
       .addRule(v => {

--- a/test/MixedTypeSpec.js
+++ b/test/MixedTypeSpec.js
@@ -437,7 +437,7 @@ describe('#MixedType', () => {
       }
     });
   });
-  it('Should be able to check by `check` with `addAsyncRule` and skip the async ', () => {
+  it('Should be able to check by `check` with `addAsyncRule` and skip the async ', (done) => {
     let called = false;
     const type = MixedType()
       .addRule(v => {
@@ -448,10 +448,12 @@ describe('#MixedType', () => {
         return false;
       }, 'error1')
       .isRequired('error2');
-
-    chai.expect(called).to.eq(false);
-    chai.expect(type.check('').hasError).to.eq(true);
-    chai.expect(type.check('1').hasError).to.eq(true);
-    chai.expect(type.check(1).hasError).to.eq(false);
+    setTimeout(() => {
+      chai.expect(called).to.eq(false);
+      chai.expect(type.check('').hasError).to.eq(true);
+      chai.expect(type.check('1').hasError).to.eq(true);
+      chai.expect(type.check(1).hasError).to.eq(false);
+      done();
+    }, 100);
   });
 });


### PR DESCRIPTION
- added addAsyncRule to allow rules to be run only in async validators.  
- added test for addAsyncRule.
- updated readme for addAsyncRule