### PR TITLE
chore: change the compilation target of TypeScript from esnext to es2019

### DIFF
--- a/tsconfig-es.json
+++ b/tsconfig-es.json
@@ -9,7 +9,7 @@
     "noUnusedLocals": true,
     "sourceMap": true,
     "moduleResolution": "node",
-    "target": "ESNext"
+    "target": "ES2019"
 
   },
   "include": ["./src/**/*.ts"]


### PR DESCRIPTION
Fix issues: 
https://github.com/rsuite/rsuite/issues/3096
https://github.com/rsuite/rsuite/issues/3101