### PR TITLE
FIx validating nested objects and arrays

### DIFF
--- a/src/ObjectType.ts
+++ b/src/ObjectType.ts
@@ -74,11 +74,15 @@ export class ObjectType<DataType = any, E = ErrorMessageType> extends MixedType<
           });
 
           return Promise.all(checkAll).then(values => {
-            values.forEach((v, index) => {
+            let hasError = false;
+            values.forEach((v: any, index: number) => {
+              if (v?.hasError) {
+                hasError = true;
+              }
               checkResult[keys[index]] = v;
             });
 
-            resolve({ object: checkResult });
+            resolve({ hasError, object: checkResult });
           });
         }
 


### PR DESCRIPTION
- I have corrected how the check result of an ObjectType was returned; basically, the "hasError" property was not being returned in the checkAsync statement, so the Form was skipping the display of errors generated by asynchronous rules.
- Additionally, I added some code to the ArrayType component, which when defining the "of" rule only added synchronous rules and not asynchronous ones.