### PR TITLE
fix: nested objects returned checkResult, execution of async rules on arrays

### DIFF
--- a/src/ObjectType.ts
+++ b/src/ObjectType.ts
@@ -74,11 +74,15 @@ export class ObjectType<DataType = any, E = ErrorMessageType> extends MixedType<
           });
 
           return Promise.all(checkAll).then(values => {
-            values.forEach((v, index) => {
+            let hasError = false;
+            values.forEach((v: any, index: number) => {
+              if (v?.hasError) {
+                hasError = true;
+              }
               checkResult[keys[index]] = v;
             });
 
-            resolve({ object: checkResult });
+            resolve({ hasError, object: checkResult });
           });
         }
 

--- a/test/ArrayTypeSpec.js
+++ b/test/ArrayTypeSpec.js
@@ -176,4 +176,33 @@ describe('#ArrayType', () => {
       .checkForField('data', { data: [1] })
       .errorMessage.should.equal('data field must have at least 2 items');
   });
+
+  it('Should call async check', done => {
+    const schema = new Schema({
+      arr1: ArrayType().addAsyncRule(() => {
+        return new Promise(resolve => {
+          setTimeout(() => {
+            resolve(false);
+          }, 1000);
+        });
+      }, 'error1'),
+      arr2: ArrayType().addAsyncRule(() => {
+        return new Promise(resolve => {
+          setTimeout(() => {
+            resolve(true);
+          }, 1000);
+        });
+      }, 'error2'),
+    });
+
+    schema.checkAsync({ arr1: [1, 2, 3], arr2: [1, 2, 3] }).then(status => {
+      if (
+        status.arr1.hasError &&
+        status.arr1.errorMessage === 'error1' &&
+        !status.arr2.hasError
+      ) {
+        done();
+      }
+    });
+  });
 });

--- a/test/ObjectTypeSpec.js
+++ b/test/ObjectTypeSpec.js
@@ -124,6 +124,7 @@ describe('#ObjectType', () => {
     schema.checkAsync({ url: 'url', user: { email: 'a', age: '10' } }).then(status => {
       const user = status.user.object;
       if (
+        status.user.hasError &&
         user.age.hasError &&
         user.age.errorMessage === 'error2' &&
         user.email.hasError &&


### PR DESCRIPTION
- Corrected the return of the check result for an ObjectType, ensuring that the "hasError" property is properly returned in the checkAsync statement. This ensures that errors generated by asynchronous rules are displayed in the Form.
- Added code to the ArrayType component to include asynchronous rules when defining the "of" rule. Previously, only synchronous rules were being included.
- Added test code to verify the behavior of these changes.