### PR TITLE
feat: add support for `label` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,37 +446,49 @@ MixedType().addAsyncRule((value, data) => {
 
 #### `when(condition: (schemaSpec: SchemaDeclaration<DataType, ErrorMsgType>) => Type)`
 
-Define data verification rules based on conditions.
+Conditional validation, the return value is a new type.
 
-```js
+```ts
 const model = SchemaModel({
-  age: NumberType().min(18, 'error'),
-  contact: MixedType().when(schema => {
-    const checkResult = schema.age.check();
-    return checkResult.hasError
-      ? StringType().isRequired('Please provide contact information')
-      : StringType();
+  option: StringType().isOneOf(['a', 'b', 'other']),
+  other: StringType().when(schema => {
+    const { value } = schema.option;
+    return value === 'other' ? StringType().isRequired('Other required') : StringType();
   })
 });
 
 /**
-{ 
-  age: { hasError: false }, 
-  contact: { hasError: false } 
+{
+  option: { hasError: false },
+  other: { hasError: false }
 }
 */
-model.check({ age: 18, contact: '' });
+model.check({ option: 'a', other: '' });
 
 /*
 {
-  age: { hasError: true, errorMessage: 'error' },
-  contact: {
-    hasError: true,
-    errorMessage: 'Please provide contact information'
-  }
+  option: { hasError: false },
+  other: { hasError: true, errorMessage: 'Other required' }
 }
 */
-model.check({ age: 17, contact: '' });
+model.check({ option: 'other', other: '' });
+```
+
+Check whether a field passes the validation to determine the validation rules of another field.
+
+```js
+const model = SchemaModel({
+  password: StringType().isRequired('Password required'),
+  confirmPassword: StringType().when(schema => {
+    const { hasError } = schema.password.check();
+    return hasError
+      ? StringType()
+      : StringType().addRule(
+          value => value === schema.password.value,
+          'The passwords are inconsistent twice'
+        );
+  })
+});
 ```
 
 #### `check(value: ValueType, data?: DataType):CheckResult`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Schema for data modeling & validation
     - [`when(condition: (schemaSpec: SchemaDeclaration<DataType, ErrorMsgType>) => Type)`](#whencondition-schemaspec-schemadeclarationdatatype-errormsgtype--type)
     - [`check(value: ValueType, data?: DataType):CheckResult`](#checkvalue-valuetype-data-datatypecheckresult)
     - [`checkAsync(value: ValueType, data?: DataType):Promise<CheckResult>`](#checkasyncvalue-valuetype-data-datatypepromisecheckresult)
+    - [`label(label: string)`](#labellabel-string)
   - [StringType(errorMessage?: string)](#stringtypeerrormessage-string)
     - [`isEmail(errorMessage?: string)`](#isemailerrormessage-string)
     - [`isURL(errorMessage?: string)`](#isurlerrormessage-string)
@@ -512,6 +513,23 @@ type.checkAsync('1').then(checkResult => {
 });
 type.checkAsync(1).then(checkResult => {
   //  { hasError: false }
+});
+```
+
+#### `label(label: string)`
+
+Overrides the key name in error messages.
+
+```js
+MixedType().label('Username');
+```
+
+Eg:
+
+```js
+SchemaModel({
+  first_name: StringType().label('First name'),
+  age: NumberType().label('Age')
 });
 ```
 

--- a/src/MixedType.ts
+++ b/src/MixedType.ts
@@ -24,6 +24,7 @@ export class MixedType<ValueType = any, DataType = any, E = ErrorMessageType, L 
   protected emptyAllowed = false;
   protected rules: RuleType<ValueType, DataType, E | string>[] = [];
   protected priorityRules: RuleType<ValueType, DataType, E | string>[] = [];
+  protected fieldLabel?: string;
 
   schemaSpec: SchemaDeclaration<DataType, E>;
   value: any;
@@ -43,7 +44,9 @@ export class MixedType<ValueType = any, DataType = any, E = ErrorMessageType, L 
     if (this.required && !checkRequired(value, this.trim, this.emptyAllowed)) {
       return {
         hasError: true,
-        errorMessage: formatErrorMessage(this.requiredMessage, { name: fieldName })
+        errorMessage: formatErrorMessage(this.requiredMessage, {
+          name: this.fieldLabel || fieldName
+        })
       };
     }
 
@@ -70,7 +73,9 @@ export class MixedType<ValueType = any, DataType = any, E = ErrorMessageType, L 
     if (this.required && !checkRequired(value, this.trim, this.emptyAllowed)) {
       return Promise.resolve({
         hasError: true,
-        errorMessage: formatErrorMessage(this.requiredMessage, { name: fieldName })
+        errorMessage: formatErrorMessage(this.requiredMessage, {
+          name: this.fieldLabel || fieldName
+        })
       });
     }
 
@@ -158,6 +163,14 @@ export class MixedType<ValueType = any, DataType = any, E = ErrorMessageType, L 
       undefined,
       true
     );
+    return this;
+  }
+
+  /**
+   * Overrides the key name in error messages.
+   */
+  label(label: string) {
+    this.fieldLabel = label;
     return this;
   }
 }

--- a/test/MixedTypeSpec.js
+++ b/test/MixedTypeSpec.js
@@ -1,6 +1,6 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const chai = require('chai');
-const schema = require('../src');
+import chai, { expect } from 'chai';
+import * as schema from '../src';
+
 chai.should();
 const { StringType, SchemaModel, NumberType, ArrayType, MixedType } = schema;
 
@@ -459,5 +459,17 @@ describe('#MixedType', () => {
         done(e);
       }
     }, 100);
+  });
+
+  it('Should use label to override the field name in the error message', () => {
+    const schema = SchemaModel({
+      first_name: StringType().label('First Name').isRequired(),
+      age: NumberType().label('Age').isRequired()
+    });
+
+    expect(schema.check({})).to.deep.equal({
+      first_name: { hasError: true, errorMessage: 'First Name is a required field' },
+      age: { hasError: true, errorMessage: 'Age is a required field' }
+    });
   });
 });


### PR DESCRIPTION
#### `label(label: string)`

Overrides the key name in error messages.

```js
MixedType().label('Username');
```

Eg:

```js
SchemaModel({
  first_name: StringType().label('First name'),
  age: NumberType().label('Age')
});
```